### PR TITLE
increase cURL timeout

### DIFF
--- a/package/src/Console/Command/InitializeCommand.php
+++ b/package/src/Console/Command/InitializeCommand.php
@@ -92,6 +92,7 @@ class InitializeCommand extends Command
             '',
             array(
                 'adapter' => 'Zend\Http\Client\Adapter\Curl',
+                'timeout' => 60,
                 'curloptions' => array(
                     CURLOPT_SSL_VERIFYPEER => (bool) $app->make('config')->get('app.curl.verifyPeer'),
                 ),


### PR DESCRIPTION
Regarding this: https://github.com/concrete5/addon_community_translation/issues/8
I don't get a timeout anymore, but I still can't fetch the translation, 4th attempt!

```
Working on pt_BR
 - checking Locale entity... updated.
 - working on 5.6.2
   > fetching translations for 5.6.2... done.
   > parsing translations... done (3016 strings).
   > saving... done.
 - working on 5.6.2.1
   > fetching translations for 5.6.2.1... done.
   > parsing translations... done (3024 strings).
   > saving... done.
 - working on 5.6.3
   > fetching translations for 5.6.3... Error in cURL request: Failed to connect to www.transifex.com port 443: Timed out
```
