### PR TITLE
Add a `x-concrete5-token` header

### DIFF
--- a/src/RemotePackage/Importer.php
+++ b/src/RemotePackage/Importer.php
@@ -109,6 +109,7 @@ class Importer
             'outputstream' => $zipFilename,
         ]);
         $request = new Request();
+        $request->getHeaders()->addHeaderLine('x-concrete5-token', '' . getenv('CONCRETE5_TOKEN'));
         $request->setMethod('GET')->setUri($remotePackage->getArchiveUrl());
         $response = $this->httpClient->send($request);
         $this->httpClient->reset();

--- a/src/RemotePackage/Importer.php
+++ b/src/RemotePackage/Importer.php
@@ -109,7 +109,11 @@ class Importer
             'outputstream' => $zipFilename,
         ]);
         $request = new Request();
-        $request->getHeaders()->addHeaderLine('x-concrete5-token', '' . getenv('CONCRETE5_TOKEN'));
+        
+        if (($header = (string) getenv('CT_REMOTEPACKAGE_HEADER')) && 
+            $value = (string) getenv('CT_REMOTEPACKAGE_HEADER_VALUE')) {
+            $request->getHeaders()->addHeaderLine($header, $value);
+        }
         $request->setMethod('GET')->setUri($remotePackage->getArchiveUrl());
         $response = $this->httpClient->send($request);
         $this->httpClient->reset();


### PR DESCRIPTION
This makes it possible for us to uniquely identify the translation server and allow it to download packages without a license.