### PR TITLE
Version 9 support

### DIFF
--- a/controllers/search/packages.php
+++ b/controllers/search/packages.php
@@ -28,7 +28,7 @@ class Packages extends AbstractController
     public function getStickyRequest()
     {
         if ($this->stickyRequest === null) {
-            $this->stickyRequest = $this->app->make(StickyRequest::class, ['community_translation.packages']);
+            $this->stickyRequest = $this->app->make(StickyRequest::class, ['namespace' => 'community_translation.packages']);
         }
 
         return $this->stickyRequest;
@@ -49,7 +49,7 @@ class Packages extends AbstractController
     public function getSearchList()
     {
         if ($this->searchList === null) {
-            $this->searchList = $this->app->make(SearchList::class, [$this->getStickyRequest()]);
+            $this->searchList = $this->app->make(SearchList::class, ['il' => $this->getStickyRequest()]);
         }
 
         return $this->searchList;

--- a/src/Service/EntitiesEventSubscriber.php
+++ b/src/Service/EntitiesEventSubscriber.php
@@ -5,7 +5,7 @@ namespace CommunityTranslation\Service;
 use CommunityTranslation\Entity\Package as PackageEntity;
 use CommunityTranslation\Entity\Package\Version as PackageVersionEntity;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Events;
 


### PR DESCRIPTION
V9 includes the v2+ version of doctrine persistence which has some different class locations. This is the only change I needed to get things rendering but more may be needed for complete compatibility.