### PR TITLE
Fix exporting translations with plurals

### DIFF
--- a/controllers/frontend/online_translation.php
+++ b/controllers/frontend/online_translation.php
@@ -1122,22 +1122,21 @@ class OnlineTranslation extends Controller
         $t = $translations->insert($translatable->getContext(), $translatable->getText(), $translatable->getPlural());
         $t->setTranslation($translation->getText0());
         if ($translatable->getPlural() !== '') {
-            switch ($locale->getPluralCount()) {
-                case 6:
-                    $t->setPluralTranslation($translation->getText5(), 4);
-                    // no break
-                case 5:
-                    $t->setPluralTranslation($translation->getText4(), 3);
-                    // no break
-                case 4:
-                    $t->setPluralTranslation($translation->getText3(), 2);
-                    // no break
-                case 3:
+            $numPlurals = $locale->getPluralCount();
+            if ($numPlurals >= 2) {
+                $t->setPluralTranslation($translation->getText1(), 0);
+                if ($numPlurals >= 3) {
                     $t->setPluralTranslation($translation->getText2(), 1);
-                    // no break
-                case 2:
-                    $t->setPluralTranslation($translation->getText1(), 0);
-                    break;
+                    if ($numPlurals >= 4) {
+                        $t->setPluralTranslation($translation->getText3(), 2);
+                        if ($numPlurals >= 5) {
+                            $t->setPluralTranslation($translation->getText4(), 3);
+                            if ($numPlurals >= 6) {
+                                $t->setPluralTranslation($translation->getText5(), 4);
+                            }
+                        }
+                    }
+                }
             }
         }
         if ($markAsFuzzy) {

--- a/src/Translation/Exporter.php
+++ b/src/Translation/Exporter.php
@@ -69,22 +69,8 @@ EOT
             }
             $translation->setTranslation($row['text0']);
             if ($plural !== '') {
-                switch ($numPlurals) {
-                    case 6:
-                        $translation->setPluralTranslation($row['text5'], 4);
-                        // no break
-                    case 5:
-                        $translation->setPluralTranslation($row['text4'], 3);
-                        // no break
-                    case 4:
-                        $translation->setPluralTranslation($row['text3'], 2);
-                        // no break
-                    case 3:
-                        $translation->setPluralTranslation($row['text2'], 1);
-                        // no break
-                    case 2:
-                        $translation->setPluralTranslation($row['text1'], 0);
-                        break;
+                for ($index = 1; $index < $numPlurals; $index++) {
+                    $translation->setPluralTranslation($row['text' . $index], $index - 1);
                 }
             }
         }
@@ -304,22 +290,8 @@ EOT
                 }
                 $translation->setTranslation($row['text0']);
                 if ($translation->hasPlural()) {
-                    switch ($numPlurals) {
-                        case 6:
-                            $translation->setPluralTranslation($row['text5'], 4);
-                            // no break
-                        case 5:
-                            $translation->setPluralTranslation($row['text4'], 3);
-                            // no break
-                        case 4:
-                            $translation->setPluralTranslation($row['text3'], 2);
-                            // no break
-                        case 3:
-                            $translation->setPluralTranslation($row['text2'], 1);
-                            // no break
-                        case 2:
-                            $translation->setPluralTranslation($row['text1'], 0);
-                            break;
+                    for ($index = 1; $index < $numPlurals; $index++) {
+                        $translation->setPluralTranslation($row['text' . $index], $index - 1);
                     }
                 }
             }


### PR DESCRIPTION
Before:

```po
msgid "..."
msgid_plural "..."
msgstr[0] "..."
msgstr[2] "..."
msgstr[1] "..."
```

After:

```po
msgid "..."
msgid_plural "..."
msgstr[0] "..."
msgstr[1] "..."
msgstr[2] "..."
```