### PR TITLE
Use OIDC JWTs to authenticate /api/import/package requests

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -16,7 +16,7 @@ return [
         Api\EntryPoint\GetPackageVersionLocales::ACCESS_KEY => Api\UserControl::ACCESSOPTION_EVERYBODY,
         Api\EntryPoint\GetPackageVersionTranslations::ACCESS_KEY => Api\UserControl::ACCESSOPTION_EVERYBODY,
         Api\EntryPoint\FillTranslations::ACCESS_KEY => Api\UserControl::ACCESSOPTION_EVERYBODY,
-        Api\EntryPoint\ImportPackage::ACCESS_KEY => Api\UserControl::ACCESSOPTION_GLOBALADMINS,
+        Api\EntryPoint\ImportPackage::ACCESS_KEY => Api\UserControl::ACCESSOPTION_MARKET,
         Api\EntryPoint\ImportPackageVersionTranslatables::ACCESS_KEY => Api\UserControl::ACCESSOPTION_GLOBALADMINS,
         Api\EntryPoint\ImportTranslations::ACCESS_KEY_WITHOUTAPPROVE => Api\UserControl::ACCESSOPTION_TRANSLATORS_OWNLOCALES,
         Api\EntryPoint\ImportTranslations::ACCESS_KEY_WITHAPPROVE => Api\UserControl::ACCESSOPTION_LOCALEADMINS_OWNLOCALES,

--- a/controllers/single_page/dashboard/community_translation/options/api.php
+++ b/controllers/single_page/dashboard/community_translation/options/api.php
@@ -123,6 +123,7 @@ class Api extends DashboardPageController
                 UserControl::ACCESSOPTION_GLOBALADMINS => t('Global localization administrators'),
                 UserControl::ACCESSOPTION_SITEADMINS => t('Site administrators'),
                 UserControl::ACCESSOPTION_ROOT => t('Site administrator'),
+                UserControl::ACCESSOPTION_MARKET => t('Concrete Marketplace'),
                 UserControl::ACCESSOPTION_NOBODY => t('Nobody'),
             ]
             :
@@ -134,6 +135,7 @@ class Api extends DashboardPageController
                 UserControl::ACCESSOPTION_GLOBALADMINS => t('Global localization administrators'),
                 UserControl::ACCESSOPTION_SITEADMINS => t('Site administrators'),
                 UserControl::ACCESSOPTION_ROOT => t('Site administrator'),
+                UserControl::ACCESSOPTION_MARKET => t('Concrete Marketplace'),
                 UserControl::ACCESSOPTION_NOBODY => t('Nobody'),
             ]
         ;

--- a/src/Api/Jwt/SignedWithOidc.php
+++ b/src/Api/Jwt/SignedWithOidc.php
@@ -23,8 +23,8 @@ use Stash\Interfaces\ItemInterface;
 
 class SignedWithOidc implements SignedWith, LoggerAwareInterface
 {
-
     use LoggerAwareTrait;
+
     public function __construct(
         protected ExpensiveCache $cache,
         protected Client $client,
@@ -65,6 +65,11 @@ class SignedWithOidc implements SignedWith, LoggerAwareInterface
         (new JwtSignedWith($signer, InMemory::plainText($key)))->assert($token);
     }
 
+    public function getLoggerChannel(): string
+    {
+        return Channels::CHANNEL_API;
+    }
+
     protected function getKey(string $issuer, string $kid): ?string
     {
         $jwks = $this->getJwkUri($issuer);
@@ -93,6 +98,7 @@ class SignedWithOidc implements SignedWith, LoggerAwareInterface
             }
         } catch (\Throwable $e) {
             $this->logger?->warning('Unable to load OIDC JWKs: ' . $e->getMessage());
+
             return null;
         }
 
@@ -103,6 +109,7 @@ class SignedWithOidc implements SignedWith, LoggerAwareInterface
 
                 if ($e === '' || $n === '') {
                     $this->logger?->warning('Unable to load OIDC JWK, invalid base64');
+
                     return null;
                 }
 
@@ -113,6 +120,7 @@ class SignedWithOidc implements SignedWith, LoggerAwareInterface
                     ]);
                 } catch (\Throwable $e) {
                     $this->logger?->warning('Unable to load OIDC key: ' . $e->getMessage());
+
                     return null;
                 }
             }
@@ -149,15 +157,11 @@ class SignedWithOidc implements SignedWith, LoggerAwareInterface
             }
         } catch (\Throwable $e) {
             $this->logger?->warning('Unable to load OIDC configuration: ' . $e->getMessage());
+
             return null;
         }
 
         return $data['jwks_uri'] ?? null;
-    }
-
-    public function getLoggerChannel(): string
-    {
-        return Channels::CHANNEL_API;
     }
 
     private function cacheResponse(ItemInterface $cacheItem, string $json, ResponseInterface $response): void

--- a/src/Api/Jwt/SignedWithOidc.php
+++ b/src/Api/Jwt/SignedWithOidc.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace CommunityTranslation\Api\Jwt;
+
+use Concrete\Core\Cache\Level\ExpensiveCache;
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerAwareInterface;
+use Concrete\Core\Logging\LoggerAwareTrait;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Signer\Rsa\Sha384;
+use Lcobucci\JWT\Signer\Rsa\Sha512;
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\SignedWith as JwtSignedWith;
+use Lcobucci\JWT\Validation\ConstraintViolation;
+use Lcobucci\JWT\Validation\SignedWith;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Math\BigInteger;
+use Psr\Http\Message\ResponseInterface;
+use Stash\Interfaces\ItemInterface;
+
+class SignedWithOidc implements SignedWith, LoggerAwareInterface
+{
+
+    use LoggerAwareTrait;
+    public function __construct(
+        protected ExpensiveCache $cache,
+        protected Client $client,
+    ) {}
+
+    public function assert(Token $token): void
+    {
+        $issuer = (string) $token->claims()->get('iss');
+        $kid = (string) $token->headers()->get('kid');
+        $algo = (string) $token->headers()->get('alg');
+
+        // Make sure we have an authorized issuer
+        match (true) {
+            $issuer === '' => throw new ConstraintViolation('Token missing iss claim'),
+            $kid === '' => throw new ConstraintViolation('Token missing kid header'),
+            $algo === '' => throw new ConstraintViolation('Token missing alg header'),
+            default => null,
+        };
+
+        if (!preg_match($_ENV['MARKETPLACE_ISSUER_REGEX'] ?? '~^https://market.concretecms.org/?$~', $issuer)) {
+            throw new ConstraintViolation('Access denied, invalid issuer');
+        }
+
+        // Make sure the key is signed with a valid market key, is valid now, and is permitted for us
+        $key = $this->getKey($issuer, $kid);
+
+        $signer = match ($algo) {
+            'RS256' => new Sha256(),
+            'RS384' => new Sha384(),
+            'RS512' => new Sha512(),
+            default => throw new ConstraintViolation(sprintf(
+                'Access denied, unsupported token algorithm "%s"',
+                preg_replace('/[^[:alnum:]]/', '', $algo)
+            )),
+        };
+
+        // Assert the given token is signed with the expected key
+        (new JwtSignedWith($signer, InMemory::plainText($key)))->assert($token);
+    }
+
+    protected function getKey(string $issuer, string $kid): ?string
+    {
+        $jwks = $this->getJwkUri($issuer);
+        if (!$jwks) {
+            return null;
+        }
+
+        $issuerKey = hash('sha256', $issuer);
+        $cacheKey = "ct.oidc.{$issuerKey}.jwk";
+        $cacheItem = $this->cache->getItem($cacheKey);
+
+        try {
+            if ($cacheItem->isHit()) {
+                $json = $cacheItem->get();
+                $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            } else {
+                $response = $this->client->get($jwks, [RequestOptions::HEADERS => ['Accept' => 'application/json']]);
+                if ($response->getStatusCode() !== 200) {
+                    return null;
+                }
+
+                $json = $response->getBody()->getContents();
+                $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+                $this->cacheResponse($cacheItem, $json, $response);
+            }
+        } catch (\Throwable $e) {
+            $this->logger?->warning('Unable to load OIDC JWKs: ' . $e->getMessage());
+            return null;
+        }
+
+        foreach ($data['keys'] ?? [] as $key) {
+            if ($key['kid'] === $kid) {
+                $e = base64_decode($key['e'] ?? '');
+                $n = base64_decode(strtr($key['n'] ?? '', '-_', '+/'), true);
+
+                if ($e === '' || $n === '') {
+                    $this->logger?->warning('Unable to load OIDC JWK, invalid base64');
+                    return null;
+                }
+
+                try {
+                    return PublicKeyLoader::load([
+                        'e' => new BigInteger($e, 256),
+                        'n' => new BigInteger($n, 256),
+                    ]);
+                } catch (\Throwable $e) {
+                    $this->logger?->warning('Unable to load OIDC key: ' . $e->getMessage());
+                    return null;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function getJwkUri(string $issuer): ?string
+    {
+        $issuerKey = hash('sha256', $issuer);
+        $cacheKey = "ct.oidc.{$issuerKey}";
+
+        $cacheItem = $this->cache->getItem($cacheKey);
+
+        try {
+            if ($cacheItem->isHit()) {
+                $json = $cacheItem->get();
+                $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            } else {
+                $metadataUri = rtrim($issuer, '/') . '/.well-known/openid-configuration';
+                $response = $this->client->get(
+                    $metadataUri,
+                    [RequestOptions::HEADERS => ['Accept' => 'application/json']]
+                );
+                if ($response->getStatusCode() !== 200) {
+                    return null;
+                }
+
+                $json = $response->getBody()->getContents();
+                $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+                $this->cacheResponse($cacheItem, $json, $response);
+            }
+        } catch (\Throwable $e) {
+            $this->logger?->warning('Unable to load OIDC configuration: ' . $e->getMessage());
+            return null;
+        }
+
+        return $data['jwks_uri'] ?? null;
+    }
+
+    public function getLoggerChannel(): string
+    {
+        return Channels::CHANNEL_API;
+    }
+
+    private function cacheResponse(ItemInterface $cacheItem, string $json, ResponseInterface $response): void
+    {
+        preg_match('/max-age=(\d+)/', $response->getHeader('Cache-Control')[0] ?? '', $matches);
+        $duration = (int) ($matches[1] ?? 0);
+
+        if ($duration > 0) {
+            $cacheItem->set($json);
+            $cacheItem->setTTL($duration);
+            $cacheItem->save();
+        }
+    }
+}

--- a/src/Api/UserControl.php
+++ b/src/Api/UserControl.php
@@ -128,6 +128,7 @@ class UserControl
                 return;
             case self::ACCESSOPTION_MARKET:
                 $this->validateMarketToken();
+
                 return;
             case self::ACCESSOPTION_ROOT:
                 $user = $this->getRequestUser();
@@ -202,7 +203,6 @@ class UserControl
                 }
 
                 return $this->getApprovedLocales();
-
             case self::ACCESSOPTION_MARKET:
                 throw new AccessDeniedException();
             case self::ACCESSOPTION_ROOT:
@@ -412,7 +412,7 @@ class UserControl
     /**
      * @throws AccessDeniedException
      */
-    public function validateMarketToken(): void
+    private function validateMarketToken(): void
     {
         // Extract the JWT from the request if one exists
         try {
@@ -427,7 +427,6 @@ class UserControl
 
         // Validate the token was signed with valid OIDC, is valid now, and is permitted for translate
         try {
-
             // Use service locator to load SignedWithOidc so that we don't load expensive cache / config when not needed
             $signedWithOidc = $this->app->make(SignedWithOidc::class);
             (new Validator())->assert(


### PR DESCRIPTION
This PR adds a new `UserControl` authentication method that relies on OIDC signed JWTs.

OIDC JWT auth works by doing the following:

1. Validating the token claims and headers:
    - `iss` or "Issuer" claim is an authorized issuer
    - `alg` or "Signing algorithm" header is a supported algorithm
    - `exp` or "Expiration" claim is in the future
    - `nbf` or "Not before" claim is in the past
    - `aud` or "Audience" claim is "https://translate.concretecms.org" (This can be the same for prod / stage/ dev)
    - `kid` or "Key ID" header is set
2. Loading the declared signing key from the authorized issuer:
    - Load `{issuer}/.well-known/openid-configuration` to get the `jwks_uri`
    - Load the `jwks_uri` to get the array of [JWKs](https://datatracker.ietf.org/doc/html/rfc7517)
    - Filtering the keys to the one with the matching `kid`
3. Validating the signature against the loaded JWK

This form of authentication is preferred over shared token auth because:

1. It uses short lived tokens that expire after a minute instead of a "forever token" that lasts forever
2. Keys can be rotated without needing to update translation, so they are set to rotate automatically regularly
3. Authentication can happen using _only_ public information, no need to grant translation special access to secrets in order to authenticate requests