### PR TITLE
Add the error message to the failed token parse response

### DIFF
--- a/src/Api/UserControl.php
+++ b/src/Api/UserControl.php
@@ -437,8 +437,8 @@ class UserControl
             );
         } catch (RequiredConstraintsViolated $e) {
             throw new AccessDeniedException(t('Access denied, %s', $e->getMessage()));
-        } catch (\Throwable) {
-            throw new AccessDeniedException(t('Access denied, unable to validate token.'));
+        } catch (\Throwable $e) {
+            throw new AccessDeniedException(t('Access denied, unable to validate token. %s', $e->getMessage()));
         }
     }
 }


### PR DESCRIPTION
This will help us pin down why parsing the JWT fails intermittently.